### PR TITLE
Implement multiple breakpoints (again)

### DIFF
--- a/src/inferior_load.c
+++ b/src/inferior_load.c
@@ -5,6 +5,8 @@
 #include <sys/wait.h>
 #include <assert.h>
 #include <errno.h>
+#include <sys/personality.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -12,6 +14,10 @@ static inferior_t g_inferior;
 
 static void setup_inferior(const char *path, char *const argv[])
 {
+  unsigned long old = personality(0xFFFFFFFF);
+  if (personality(old | ADDR_NO_RANDOMIZE) < 0) {
+    perror("Failed to set personality:");
+  }
   ptrace_util_traceme();
   execv(path, argv);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(. ../include)
 
 set(TESTS test_exec
           test_breakpoint
+	  test_multiple_breakpoints
 	  test_multi_breakpoint)
 
 foreach(TEST ${TESTS})

--- a/test/test_breakpoint.c
+++ b/test/test_breakpoint.c
@@ -2,6 +2,8 @@
 #include <trap.h>
 #include <unistd.h>
 
+const char *ADDRESS_OF_MAIN = (char*)0x0000555555555151;
+
 int g_breakpoint_count = 0;
 trap_inferior_t g_inferior = 0;
 trap_breakpoint_t g_bp = 0;
@@ -20,7 +22,7 @@ int main()
 
   trap_breakpoint_set_callback(breakpoint_callback);
   g_inferior = trap_inferior_exec("./inferiors/hello", argv);
-  g_bp = trap_inferior_set_breakpoint(g_inferior, (char *)0x000000000040079d);
+  g_bp = trap_inferior_set_breakpoint(g_inferior, ADDRESS_OF_MAIN);
   trap_inferior_continue(g_inferior);
 
   assert(g_breakpoint_count == 1);

--- a/test/test_multi_breakpoint.c
+++ b/test/test_multi_breakpoint.c
@@ -2,6 +2,8 @@
 #include <trap.h>
 #include <unistd.h>
 
+const char *ADDRESS_OF_FOO = (char*)0x0000555555555131;
+
 int g_breakpoint_count = 0;
 trap_inferior_t g_inferior = 0;
 trap_breakpoint_t g_bp = 0;
@@ -20,7 +22,7 @@ int main()
 
   trap_breakpoint_set_callback(breakpoint_callback);
   g_inferior = trap_inferior_exec("./inferiors/loop", argv);
-  g_bp = trap_inferior_set_breakpoint(g_inferior, (char *)0x000000000040076d);
+  g_bp = trap_inferior_set_breakpoint(g_inferior, ADDRESS_OF_FOO);
   trap_inferior_continue(g_inferior);
 
   assert(g_breakpoint_count == 5);

--- a/test/test_multiple_breakpoints.c
+++ b/test/test_multiple_breakpoints.c
@@ -2,6 +2,9 @@
 #include <trap.h>
 #include <unistd.h>
 
+const char *ADDRESS_OF_MAIN = (char*)0x0000555555555140;
+const char *ADDRESS_OF_FOO  = (char*)0x0000555555555131;
+
 int g_foo_count = 0;
 int g_main_count = 0;
 
@@ -26,8 +29,8 @@ int main()
 
   trap_breakpoint_set_callback(breakpoint_callback);
   g_inferior = trap_inferior_exec("./inferiors/loop", argv);
-  g_bp_main = trap_inferior_set_breakpoint(g_inferior, (char *)0x0000000000400778);
-  g_bp_foo  = trap_inferior_set_breakpoint(g_inferior, (char *)0x000000000040076d);
+  g_bp_main = trap_inferior_set_breakpoint(g_inferior, ADDRESS_OF_MAIN);
+  g_bp_foo  = trap_inferior_set_breakpoint(g_inferior, ADDRESS_OF_FOO);
   trap_inferior_continue(g_inferior);
 
   assert(g_main_count == 1);

--- a/test/test_multiple_breakpoints.c
+++ b/test/test_multiple_breakpoints.c
@@ -1,0 +1,37 @@
+#include <assert.h>
+#include <trap.h>
+#include <unistd.h>
+
+int g_foo_count = 0;
+int g_main_count = 0;
+
+trap_inferior_t g_inferior = 0;
+trap_breakpoint_t g_bp_main = 0;
+trap_breakpoint_t g_bp_foo  = 0;
+
+void breakpoint_callback(trap_inferior_t inferior, trap_breakpoint_t bp)
+{
+  assert(inferior == g_inferior);
+
+  if (bp == g_bp_main) {
+    g_main_count++;
+  } else if (bp == g_bp_foo) {
+    g_foo_count++;
+  }
+}
+
+int main()
+{
+  char *argv[1] = { 0 };
+
+  trap_breakpoint_set_callback(breakpoint_callback);
+  g_inferior = trap_inferior_exec("./inferiors/loop", argv);
+  g_bp_main = trap_inferior_set_breakpoint(g_inferior, (char *)0x0000000000400778);
+  g_bp_foo  = trap_inferior_set_breakpoint(g_inferior, (char *)0x000000000040076d);
+  trap_inferior_continue(g_inferior);
+
+  assert(g_main_count == 1);
+  assert(g_foo_count == 5);
+
+  return 0;
+}


### PR DESCRIPTION
New test: test_multiple_breakpoints which sets breakpoints at multiple locations.

Implementation of multiple breakpoints.  This makes a structural change to `breakpoint_handle` so that it handles both
starting and finishing the single step in one call.  This was it can hold onto the breakpoint record as resolving the breakpoint after the single step is not possible.